### PR TITLE
feat(ui): upgrade PyQt5 to PyQt6 for native OS theme alignment

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 import sys
 import os
 import json
-from PyQt5.QtWidgets import QApplication, QMainWindow, QWidget, QVBoxLayout, QPushButton, QColorDialog, QLabel, QMenu, QGridLayout, QAction
-from PyQt5.QtGui import QColor
-from PyQt5.QtCore import Qt, QStandardPaths
+from PyQt6.QtWidgets import QApplication, QMainWindow, QWidget, QVBoxLayout, QPushButton, QColorDialog, QLabel, QMenu, QGridLayout
+from PyQt6.QtGui import QColor, QAction
+from PyQt6.QtCore import Qt, QStandardPaths
 
 class ColorPaletteApp(QMainWindow):
     def __init__(self):
@@ -70,7 +70,7 @@ class ColorPaletteApp(QMainWindow):
 
         def context_menu_handler(event):
             # Handle right-click context menu for color items
-            if event.button() == Qt.RightButton:
+            if event.button() == Qt.MouseButton.RightButton:
                 context_menu = QMenu(self)
                 hex_action = context_menu.addAction("Copy HEX")
                 rgb_action = context_menu.addAction("Copy RGBA")
@@ -80,7 +80,7 @@ class ColorPaletteApp(QMainWindow):
                 rgb_action.triggered.connect(lambda: self.copy_to_clipboard(str(color.getRgb())))
                 remove_action.triggered.connect(lambda: self.remove_color(color, color_widget))
 
-                context_menu.exec_(event.globalPos())
+                context_menu.exec(event.globalPosition().toPoint())
 
         color_widget.mousePressEvent = context_menu_handler
 
@@ -124,7 +124,7 @@ class ColorPaletteApp(QMainWindow):
 
     def get_session_data_path(self):
         # Get the path for storing session data (JSON file)
-        documents_dir = QStandardPaths.writableLocation(QStandardPaths.DocumentsLocation)
+        documents_dir = QStandardPaths.writableLocation(QStandardPaths.StandardLocation.DocumentsLocation)
         app_data_dir = os.path.join(documents_dir, "ColorPalette_data")
         os.makedirs(app_data_dir, exist_ok=True)
         return os.path.join(app_data_dir, "session_data.json")
@@ -148,9 +148,10 @@ class ColorPaletteApp(QMainWindow):
 
 def main():
     app = QApplication(sys.argv)
+    app.setStyle('Fusion')
     main_window = ColorPaletteApp()
     main_window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This also resolves an issue where the application does not apply the native (dark) theme on Windows 11.

- Upgraded from PyQt5 to PyQt6 for enhanced performance and reduced memory consumption.
- The application's theme will now automatically align with the operating system's native theme.

## Before

<img src="https://github.com/ART3MISTICAL/color-pallete/assets/16103757/0787a77b-b8cf-4ec3-8ba3-9cac129e3cec" width=50% height=50%>

## After

<img src="https://github.com/ART3MISTICAL/color-pallete/assets/16103757/7a59f591-7da4-4065-a5c0-6371c2fff870" width=50% height=50%>