### PR TITLE
Fixed requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-PyQt5
+PyQt6


### PR DESCRIPTION
The commit that updated the PyQt version didn't update the requirements file, which broke the program's installation. I updated the requirements file to have PyQt6 instead of PyQt5.